### PR TITLE
Handle invalid tunnel configs gracefully; harden `GenSecret` and add tests

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -177,16 +177,24 @@ func (client *Client) startTCP() {
 			KeepaliveInterval: client.keepaliveInterval,
 		})
 		l.Bind(conn)
-		defer l.Close()
+
+		hasTunnel := false
 		for _, t := range client.tunnels {
 			proto, localHost, localPort, remoteHost, remotePort, reverse, err := parseTunnel(t)
 			if err != nil {
-				logrus.Fatalf("parse tunnel failed: %s", err)
+				logrus.Errorf("parse tunnel failed(%s): %s", t, err)
+				continue
 			}
+			hasTunnel = true
 			l.OpenTunnel(proto, localHost, localPort, remoteHost, remotePort, reverse)
 		}
 
-		l.Wait()
+		if !hasTunnel {
+			logrus.Warn("no valid tunnel configured, reconnect later")
+		} else {
+			l.Wait()
+		}
+		l.Close()
 		time.Sleep(1 * time.Second) // TODO: sleep smartly
 	}
 

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -11,10 +11,13 @@ var (
 )
 
 func GenSecret(secret string, keyiter int, keylen int) []byte {
-	if keyiter == 0 {
+	if len(secret) == 0 {
+		return nil
+	}
+	if keyiter <= 0 {
 		keyiter = int(secret[0])
 	}
-	if keylen == 0 {
+	if keylen <= 0 {
 		keylen = len(secret)
 	}
 	return pbkdf2.Key([]byte(secret), salt, keyiter, keylen, sha1.New)

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -1,0 +1,16 @@
+package util
+
+import "testing"
+
+func TestGenSecretWithEmptySecret(t *testing.T) {
+	if got := GenSecret("", 0, 0); got != nil {
+		t.Fatalf("expected nil secret for empty input, got len=%d", len(got))
+	}
+}
+
+func TestGenSecretWithSecret(t *testing.T) {
+	got := GenSecret("abc", 0, 0)
+	if len(got) == 0 {
+		t.Fatal("expected derived key to be non-empty")
+	}
+}


### PR DESCRIPTION
### Motivation

- Make the client robust against malformed tunnel configurations so a single bad entry does not terminate the process. 
- Prevent accidental panics or unexpected outputs from `GenSecret` when given empty input or non-positive parameters, and add unit tests to lock behavior.

### Description

- Update `Start`/`startTCP` logic so tunnel parse errors are logged with `logrus.Errorf` and skipped instead of calling `logrus.Fatalf` which exits the process. 
- Track whether any valid tunnels were opened with a `hasTunnel` flag, warn with `logrus.Warn` when none are configured, and only call `l.Wait()` when tunnels exist, then explicitly call `l.Close()` instead of deferring inside the loop. 
- Harden `GenSecret` in `pkg/util/utils.go` to return `nil` for an empty `secret`, and treat non-positive `keyiter` and `keylen` by deriving defaults from the `secret` rather than only checking for `== 0`. 
- Add unit tests in `pkg/util/utils_test.go` covering empty secret behavior and non-empty secret derivation.

### Testing

- Ran `go test ./pkg/util` and the new tests in `pkg/util/utils_test.go` passed. 
- Existing behavior of the client code was exercised manually in dev runs to confirm it no longer fatals on bad tunnel entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5eeea83148329aa1bc2de2349c861)